### PR TITLE
docs: bump Node version in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gmathieu/node-browsers
 
-This image includes the latest version of Node 8 and specific versions of Firefox ESR and Chrome (see Dockerfile ARG).
+This image includes the latest version of Node 10 and specific versions of Firefox ESR and Chrome (see Dockerfile ARG).
 It also includes the bare minimum to run on CircleCI 2.0 and common packages used for building/deployment (ex. `bash`, `curl`, `make`).
 
 ## Testing locally


### PR DESCRIPTION
Correct Node version to `10` instead of `8`.